### PR TITLE
Fix Maven versions in pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ASConfigCreator</artifactId>
         <groupId>nl.eernie.as</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.5.0-SNAPSHOT</version>
     </parent>
     <artifactId>ASConfigCreator-core</artifactId>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ASConfigCreator</artifactId>
         <groupId>nl.eernie.as</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.5.0-SNAPSHOT</version>
     </parent>
     <artifactId>ASConfigCreator-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>nl.eernie.as</groupId>
             <artifactId>ASConfigCreator-core</artifactId>
-            <version>0.4.0-SNAPSHOT</version>
+            <version>0.5.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>nl.eernie.as</groupId>
     <artifactId>ASConfigCreator</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <name>ASConfigCreator</name>
     <description>Create configs for you application server</description>
     <url>https://github.com/Eernie/ASConfigCreator</url>


### PR DESCRIPTION
The 0.4.0 version is already released, so I think the correct current version is 0.5.0-SNAPSHOT.